### PR TITLE
Add multi-architecture CI support for AMD64 and ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,16 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-build:
-    runs-on: ubuntu-latest
+  lint-and-test:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: [self-hosted, arm64]
+      fail-fast: false
 
     steps:
       - name: Checkout code
@@ -24,6 +32,8 @@ jobs:
 
       - name: Set up Docker Buildx for CLI
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
 
       - name: Install backend dependencies
         run: |
@@ -52,8 +62,8 @@ jobs:
 
       - name: Run backend tests with pre-built CLI
         run: |
-          # Use the pre-built CLI image from GHCR
-          docker run --rm \
+          # Use the pre-built CLI image from GHCR for the specific platform
+          docker run --rm --platform=${{ matrix.platform }} \
             -v $(pwd)/backend:/app/backend \
             -v $(pwd)/test_files:/app/test_files \
             -w /app/backend \
@@ -103,19 +113,22 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
 
       - name: Build Docker image with cache
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           push: false
           tags: lanbu-handy:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,key=buildx-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,key=buildx-${{ matrix.platform }}
 
   publish-docker:
     runs-on: ubuntu-latest
-    needs: lint-and-build
+    needs: lint-and-test
     permissions:
       contents: read
       packages: write
@@ -134,6 +147,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -156,6 +171,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add platform matrix to test on both linux/amd64 and linux/arm64
- Use GitHub runners for AMD64 builds and self-hosted ARM64 runner for native ARM64 performance
- Build and publish multi-arch Docker images for broader platform support
- Add platform-specific caching for optimal build performance
- Set fail-fast: false to continue testing other platforms if one fails

## Benefits
- **Native ARM64 support**: Users on Apple Silicon, Raspberry Pi, and other ARM64 devices get native Docker images
- **Performance**: ARM64 builds run natively on dedicated hardware instead of emulation
- **Compatibility verification**: Ensures the application works correctly on both architectures
- **Future-proof**: Ready for the growing ARM64 ecosystem

## Test plan
- [x] Updated CI workflow with matrix strategy for both platforms
- [x] Configured self-hosted ARM64 runner with specific labels `[self-hosted, arm64]`
- [x] Added platform-specific build caching
- [ ] Verify CI runs successfully on both platforms
- [ ] Confirm multi-arch Docker images are published correctly

🤖 Generated with [Claude Code](https://claude.ai/code)