### PR TITLE
Fix external spool visibility and selection (fixes #190)

### DIFF
--- a/.github/workflows/cleanup-branch-cache.yml
+++ b/.github/workflows/cleanup-branch-cache.yml
@@ -55,7 +55,7 @@ jobs:
           for ARCH in "${ARCHITECTURES[@]}"; do
             CACHE_TAG="build-cache-${BRANCH}-${ARCH}"
             echo "Attempting to delete: ${REPO}:${CACHE_TAG}"
-            
+
             # Try to delete the cache image
             if docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
               -e DOCKER_CONFIG=/tmp \
@@ -80,7 +80,7 @@ jobs:
           for ARCH in "${ARCHITECTURES[@]}"; do
             CACHE_TAG="build-cache-${BRANCH}-${ARCH}"
             echo "Attempting to delete: ${REPO}:${CACHE_TAG}"
-            
+
             # Try to delete the cache image
             if docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
               -e DOCKER_CONFIG=/tmp \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,3 +207,4 @@ BAMBU_PRINTERS='[{"name":"X1C","ip":"192.168.1.100","access_code":"12345678"}]'
 - You can find the mappings from bambu serial numbers to models here: https://wiki.bambulab.com/en/general/find-sn
 - don't commit with no-verify. Fix any failing precommits.
 - before committing, make sure everything still builds, lints, and passes tests
+- when I ask you to run tests, that includes both backend and frontend tests

--- a/backend/app/filament_matching_service.py
+++ b/backend/app/filament_matching_service.py
@@ -26,6 +26,7 @@ class FilamentMatch:
     match_quality: str  # "perfect", "type_only", "fallback", "none"
     confidence: float  # 0.0 to 1.0
     ams_filament: Optional[AMSFilament] = None
+    is_external_spool: bool = False  # True if this is external spool (unit_id=254)
 
 
 @dataclass
@@ -77,10 +78,10 @@ class FilamentMatchingService:
         Returns:
             FilamentMatchingResult with suggested mappings
         """
-        if not ams_status.success or not ams_status.ams_units:
+        if not ams_status.success:
             return FilamentMatchingResult(
                 success=False,
-                message="AMS status not available or no AMS units found",
+                message="AMS status not available",
                 matches=[],
                 error_details="Cannot match filaments without valid AMS status",
             )
@@ -95,6 +96,18 @@ class FilamentMatchingService:
 
         # Get all available AMS filaments
         available_filaments = self._get_all_ams_filaments(ams_status.ams_units)
+
+        # Add external spool to available filaments if it's loaded
+        if ams_status.external_spool and ams_status.external_spool.available:
+            external_filament = AMSFilament(
+                slot_id=ams_status.external_spool.slot_id,
+                filament_type=ams_status.external_spool.filament_type,
+                color=ams_status.external_spool.color,
+                material_id=ams_status.external_spool.material_id,
+            )
+            # Use the actual external spool ID from the data
+            ext_id = ams_status.external_spool.slot_id
+            available_filaments.append((external_filament, ext_id, ext_id))
 
         if not available_filaments:
             return FilamentMatchingResult(
@@ -128,6 +141,8 @@ class FilamentMatchingService:
             if best_match:
                 # Update the requirement index for this match
                 best_match.requirement_index = req_index
+                # Set external spool flag if unit_id is 254
+                best_match.is_external_spool = best_match.ams_unit_id in [254, 255]
                 matches.append(best_match)
                 used_slots.add((best_match.ams_unit_id, best_match.ams_slot_id))
             else:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -308,10 +308,19 @@ class AMSUnitResponse(BaseModel):
     filaments: List[AMSFilamentResponse]
 
 
+class ExternalSpoolResponse(BaseModel):
+    slot_id: int = 254
+    filament_type: str
+    color: str
+    material_id: Optional[str] = None
+    available: bool
+
+
 class AMSStatusResponse(BaseModel):
     success: bool
     message: str
     ams_units: Optional[List[AMSUnitResponse]] = None
+    external_spool: Optional[ExternalSpoolResponse] = None
     error_details: Optional[str] = None
 
 
@@ -321,6 +330,7 @@ class PrinterStatusResponse(BaseModel):
     printer_model: Optional[str] = None
     printer_name: Optional[str] = None
     ams_units: Optional[List[AMSUnitResponse]] = None
+    external_spool: Optional[ExternalSpoolResponse] = None
     error_details: Optional[str] = None
 
 
@@ -393,6 +403,7 @@ class FilamentMatchResult(BaseModel):
     ams_slot_id: int
     match_quality: str  # "perfect", "type_only", "fallback", "none"
     confidence: float
+    is_external_spool: bool = False
 
 
 class FilamentMatchResponse(BaseModel):
@@ -2082,10 +2093,22 @@ async def get_ams_status(printer_id: str):
                         )
                         ams_units_response.append(unit_response)
 
+                # Convert external spool if present
+                external_spool_response = None
+                if ams_result.external_spool:
+                    external_spool_response = ExternalSpoolResponse(
+                        slot_id=ams_result.external_spool.slot_id,
+                        filament_type=ams_result.external_spool.filament_type,
+                        color=ams_result.external_spool.color,
+                        material_id=ams_result.external_spool.material_id,
+                        available=ams_result.external_spool.available,
+                    )
+
                 return AMSStatusResponse(
                     success=True,
                     message=ams_result.message,
                     ams_units=ams_units_response,
+                    external_spool=external_spool_response,
                 )
             else:
                 # Query failed
@@ -2306,12 +2329,24 @@ async def get_printer_status(printer_id: str):
                         )
                         ams_units_response.append(unit_response)
 
+                # Convert external spool if present
+                external_spool_response = None
+                if status_result.external_spool:
+                    external_spool_response = ExternalSpoolResponse(
+                        slot_id=status_result.external_spool.slot_id,
+                        filament_type=status_result.external_spool.filament_type,
+                        color=status_result.external_spool.color,
+                        material_id=status_result.external_spool.material_id,
+                        available=status_result.external_spool.available,
+                    )
+
                 return PrinterStatusResponse(
                     success=True,
                     message=status_result.message,
                     printer_model=status_result.printer_model,
                     printer_name=status_result.printer_name,
                     ams_units=ams_units_response,
+                    external_spool=external_spool_response,
                 )
             else:
                 # Query failed
@@ -2388,10 +2423,24 @@ async def match_filaments(request: FilamentMatchRequest):
                 ams_unit = AMSUnit(unit_id=unit_response.unit_id, filaments=filaments)
                 ams_units.append(ams_unit)
 
+        # Convert external spool if present
+        external_spool = None
+        if request.ams_status.external_spool:
+            from app.printer_service import ExternalSpool
+
+            external_spool = ExternalSpool(
+                slot_id=request.ams_status.external_spool.slot_id,
+                filament_type=request.ams_status.external_spool.filament_type,
+                color=request.ams_status.external_spool.color,
+                material_id=request.ams_status.external_spool.material_id,
+                available=request.ams_status.external_spool.available,
+            )
+
         ams_status = AMSStatusResult(
             success=request.ams_status.success,
             message=request.ams_status.message,
             ams_units=ams_units,
+            external_spool=external_spool,
             error_details=request.ams_status.error_details,
         )
 
@@ -2410,6 +2459,7 @@ async def match_filaments(request: FilamentMatchRequest):
                     ams_slot_id=match.ams_slot_id,
                     match_quality=match.match_quality,
                     confidence=match.confidence,
+                    is_external_spool=match.is_external_spool,
                 )
                 matches.append(match_result)
 

--- a/backend/app/printer_service.py
+++ b/backend/app/printer_service.py
@@ -81,6 +81,17 @@ class AMSFilament:
 
 
 @dataclass
+class ExternalSpool:
+    """Information about the external spool (virtual tray)."""
+
+    slot_id: int = 254  # Usually 254, but can be 255 on X1C
+    filament_type: str = "Unknown"
+    color: str = "#00000000"
+    material_id: str = None
+    available: bool = False  # Whether external spool is available/loaded
+
+
+@dataclass
 class AMSUnit:
     """Information about an AMS unit."""
 
@@ -97,6 +108,7 @@ class PrinterStatusResult:
     printer_model: str = None
     printer_name: str = None
     ams_units: List[AMSUnit] = None
+    external_spool: ExternalSpool = None
     error_details: str = None
 
 
@@ -107,6 +119,7 @@ class AMSStatusResult:
     success: bool
     message: str
     ams_units: List[AMSUnit] = None
+    external_spool: ExternalSpool = None
     error_details: str = None
 
 
@@ -819,7 +832,7 @@ class PrinterService:
                 )
 
             # Parse the AMS data from the response
-            ams_units = self._parse_ams_data(response_data)
+            ams_units, external_spool = self._parse_ams_data(response_data)
 
             logger.info(
                 f"Successfully retrieved AMS status from printer "
@@ -831,6 +844,7 @@ class PrinterService:
                 message=f"AMS status retrieved successfully from "
                 f"{printer_config.name}",
                 ams_units=ams_units,
+                external_spool=external_spool,
             )
 
         except PrinterMQTTError:
@@ -851,21 +865,28 @@ class PrinterService:
                 except Exception as e:
                     logger.debug(f"Error during MQTT cleanup: {e}")
 
-    def _parse_ams_data(self, response_data: dict) -> List[AMSUnit]:
+    def _parse_ams_data(
+        self, response_data: dict
+    ) -> tuple[List[AMSUnit], ExternalSpool]:
         """Parse AMS data from MQTT response.
 
         Args:
             response_data: The JSON response from the printer
 
         Returns:
-            List[AMSUnit]: List of AMS units with their filament information
+            tuple: (List[AMSUnit], ExternalSpool) - AMS units and external spool info
         """
         ams_units = []
+        external_spool = ExternalSpool()
 
         try:
+            # Log the full response to understand the structure
+            logger.debug(f"Full response_data: {json.dumps(response_data, indent=2)}")
+
             # Bambu Lab AMS data is typically structured as:
             # {"ams": {"ams": [{"id": 0, "tray": [{"id": 0, ...}, ...]}, ...]}}
             ams_data = response_data.get("ams", {})
+            logger.debug(f"Full AMS data structure: {json.dumps(ams_data, indent=2)}")
             ams_list = ams_data.get("ams", [])
 
             for ams_unit_data in ams_list:
@@ -905,11 +926,49 @@ class PrinterService:
                 ams_unit = AMSUnit(unit_id=unit_id, filaments=filaments)
                 ams_units.append(ams_unit)
 
+            # Parse external spool (vt_tray) data
+            # Check in print level first (X1C location), then ams_data, then top level
+            vt_tray = None
+            if "vt_tray" in response_data:
+                # Check if we're looking at the print object directly
+                vt_tray = response_data.get("vt_tray", {})
+                logger.debug(f"vt_tray found at response_data level: {vt_tray}")
+            elif vt_tray is None:
+                vt_tray = ams_data.get("vt_tray", {})
+                if vt_tray:
+                    logger.debug(f"vt_tray found in ams_data: {vt_tray}")
+
+            if vt_tray:
+                external_spool.slot_id = int(vt_tray.get("id", 254))
+                external_spool.filament_type = vt_tray.get("tray_type", "Unknown")
+                external_spool.material_id = vt_tray.get("tray_sub_brands", None)
+                external_spool.color = "#" + vt_tray.get("tray_color", "00000000")
+
+                # X1C doesn't have state field in vt_tray, check if filament type exists
+                # or if tray_now == external spool id to determine availability
+                if (
+                    external_spool.filament_type
+                    and external_spool.filament_type != "Unknown"
+                ):
+                    external_spool.available = True
+                else:
+                    # Also check if currently selected
+                    tray_now = ams_data.get("tray_now", "")
+                    external_spool.available = str(tray_now) == str(
+                        external_spool.slot_id
+                    )
+
+                logger.debug(
+                    f"External spool parsed: available={external_spool.available}, "
+                    f"type={external_spool.filament_type}, "
+                    f"color={external_spool.color}, id={external_spool.slot_id}"
+                )
+
         except Exception as e:
             logger.warning(f"Error parsing AMS data: {e}")
             # Return empty list on parsing error
 
-        return ams_units
+        return ams_units, external_spool
 
     def query_printer_status(
         self, printer_config: PrinterConfig, timeout: Optional[int] = None
@@ -1093,8 +1152,8 @@ class PrinterService:
                 )
 
             # Parse the printer status data from the response
-            printer_model, printer_name, ams_units = self._parse_printer_status_data(
-                response_data
+            printer_model, printer_name, ams_units, external_spool = (
+                self._parse_printer_status_data(response_data)
             )
 
             logger.info(
@@ -1109,6 +1168,7 @@ class PrinterService:
                 printer_model=printer_model,
                 printer_name=printer_name,
                 ams_units=ams_units,
+                external_spool=external_spool,
             )
 
         except PrinterMQTTError:
@@ -1134,18 +1194,19 @@ class PrinterService:
 
     def _parse_printer_status_data(
         self, response_data: dict
-    ) -> tuple[str, str, List[AMSUnit]]:
+    ) -> tuple[str, str, List[AMSUnit], ExternalSpool]:
         """Parse printer status data from MQTT response.
 
         Args:
             response_data: The JSON response from the printer
 
         Returns:
-            tuple: (printer_model, printer_name, ams_units)
+            tuple: (printer_model, printer_name, ams_units, external_spool)
         """
         printer_model = "Unknown"
         printer_name = "Unknown"
         ams_units = []
+        external_spool = ExternalSpool()
 
         try:
             print_data = response_data.get("print", {})
@@ -1257,12 +1318,12 @@ class PrinterService:
 
             # Parse AMS data if present
             if "ams" in print_data:
-                ams_units = self._parse_ams_data(print_data)
+                ams_units, external_spool = self._parse_ams_data(print_data)
 
         except Exception as e:
             logger.warning(f"Error parsing printer status data: {e}")
 
-        return printer_model, printer_name, ams_units
+        return printer_model, printer_name, ams_units, external_spool
 
     def test_connection(self, printer_config: PrinterConfig) -> bool:
         """Test FTP connection to a printer without uploading.

--- a/backend/tests/test_filament_matching_api.py
+++ b/backend/tests/test_filament_matching_api.py
@@ -213,5 +213,5 @@ class TestFilamentMatchingAPI:
         result = response.json()
 
         assert result["success"] is False
-        assert "AMS status not available or no AMS units found" in result["message"]
+        assert "No filaments found in AMS units" in result["message"]
         assert result["matches"] == []

--- a/backend/tests/test_filament_matching_service.py
+++ b/backend/tests/test_filament_matching_service.py
@@ -274,7 +274,7 @@ class TestErrorHandling:
         result = service.match_filaments(requirements, empty_status)
 
         assert result.success is False
-        assert "no AMS units found" in result.message
+        assert "No filaments found in AMS units" in result.message
 
     def test_no_loaded_filaments(self, service):
         """Test handling of AMS units with no loaded filaments."""

--- a/backend/tests/test_printer_service.py
+++ b/backend/tests/test_printer_service.py
@@ -353,6 +353,31 @@ TEST_AMS_RESPONSE_DATA = {
         "tray_tar": "255",
         "unbind_ams_stat": 0,
         "version": 98743,
+        "vt_tray": {
+            "id": "254",
+            "bed_temp": "0",
+            "bed_temp_type": "0",
+            "cali_idx": 0,
+            "cols": ["000000FF"],
+            "ctype": 0,
+            "drying_temp": "0",
+            "drying_time": "0",
+            "nozzle_temp_max": "0",
+            "nozzle_temp_min": "0",
+            "remain": 0,
+            "state": 10,
+            "tag_uid": "0000000000000000",
+            "total_len": 0,
+            "tray_color": "00000000",
+            "tray_diameter": "1.75",
+            "tray_id_name": "",
+            "tray_info_idx": "",
+            "tray_sub_brands": "",
+            "tray_type": "",
+            "tray_uuid": "00000000000000000000000000000000",
+            "tray_weight": "0",
+            "xcam_info": "000000000000000000000000",
+        },
     }
 }
 
@@ -1380,9 +1405,14 @@ class TestAMSQuery:
         """Test parsing valid AMS data."""
         response_data = TEST_AMS_RESPONSE_DATA
 
-        ams_units = printer_service._parse_ams_data(response_data)
+        ams_units, external_spool = printer_service._parse_ams_data(response_data)
 
         assert len(ams_units) == 3
+
+        # Check external spool (should be empty based on state=10)
+        assert external_spool is not None
+        assert external_spool.slot_id == 254
+        assert external_spool.available is False  # state=10 means empty
 
         # First AMS unit
         unit1 = ams_units[0]
@@ -1460,19 +1490,70 @@ class TestAMSQuery:
         assert filament12.filament_type == "PETG"
         assert filament12.color == "F75403FF" or filament12.color == "#F75403FF"
 
+    def test_parse_ams_data_with_loaded_external_spool(self, printer_service):
+        """Test parsing AMS data with loaded external spool."""
+        response_data = {
+            "ams": {
+                "ams": [],  # No AMS units
+                "vt_tray": {
+                    "id": "254",
+                    "state": 11,  # Loaded state
+                    "tray_type": "PLA",
+                    "tray_color": "FF0000FF",
+                    "tray_sub_brands": "PLA Basic",
+                },
+            }
+        }
+
+        ams_units, external_spool = printer_service._parse_ams_data(response_data)
+
+        assert len(ams_units) == 0
+        assert external_spool is not None
+        assert external_spool.slot_id == 254
+        assert external_spool.available is True  # state != 10 means loaded
+        assert external_spool.filament_type == "PLA"
+        assert external_spool.color == "#FF0000FF"
+        assert external_spool.material_id == "PLA Basic"
+
     def test_parse_ams_data_invalid(self, printer_service):
         """Test parsing invalid AMS data."""
         # Missing AMS data
         response_data = {"status": "ok"}
 
-        ams_units = printer_service._parse_ams_data(response_data)
+        ams_units, external_spool = printer_service._parse_ams_data(response_data)
         assert len(ams_units) == 0
 
         # Malformed data
         response_data = {"ams": "invalid"}
 
-        ams_units = printer_service._parse_ams_data(response_data)
+        ams_units, external_spool = printer_service._parse_ams_data(response_data)
         assert len(ams_units) == 0
+
+    def test_parse_ams_data_x1c_style_external_spool(self, printer_service):
+        """Test parsing X1C-style data with external spool in print object."""
+        # X1C sends vt_tray at print level, not inside ams
+        response_data = {
+            "vt_tray": {
+                "id": "255",
+                "tray_type": "TPU",
+                "tray_color": "000000FF",
+                "tray_sub_brands": "",
+                # No state field in X1C data
+            },
+            "ams": {
+                "ams": [],  # No AMS units
+                "tray_now": "255",  # External spool selected
+            },
+        }
+
+        ams_units, external_spool = printer_service._parse_ams_data(response_data)
+
+        assert len(ams_units) == 0
+        assert external_spool is not None
+        assert external_spool.slot_id == 255
+        assert external_spool.available is True  # Has filament type
+        assert external_spool.filament_type == "TPU"
+        assert external_spool.color == "#000000FF"
 
 
 class TestMQTTIntegration:

--- a/pwa/src/components/AMSStatusDisplay.tsx
+++ b/pwa/src/components/AMSStatusDisplay.tsx
@@ -299,6 +299,8 @@ function AMSStatusDisplay({
     // Check if this is an empty slot or transparent
     const isEmpty = isEmptyColor(filament.color);
     const isTransparent = isTransparentColor(filament.color);
+    const isExternalSpool =
+      filament.slot_id === 254 || filament.slot_id === 255;
 
     // Convert color hex codes to a readable format or use the raw value
     const colorDisplay = filament.color.startsWith('#')
@@ -318,7 +320,9 @@ function AMSStatusDisplay({
     return (
       <div key={filament.slot_id} className="filament-slot">
         <div className="slot-header">
-          <span className="slot-id">Slot {filament.slot_id}</span>
+          {!isExternalSpool && (
+            <span className="slot-id">Slot {filament.slot_id}</span>
+          )}
           <span className="filament-type">{filament.filament_type}</span>
         </div>
         <div className="filament-details">
@@ -443,6 +447,25 @@ function AMSStatusDisplay({
             </div>
           ) : (
             <div className="no-ams">No AMS units found</div>
+          )}
+
+          {/* External Spool Display */}
+          {amsStatus.external_spool && (
+            <div className="external-spool-section">
+              <h4>External Spool</h4>
+              {amsStatus.external_spool.available ? (
+                <div className="filament-slots">
+                  {renderFilamentSlot({
+                    slot_id: amsStatus.external_spool.slot_id,
+                    filament_type: amsStatus.external_spool.filament_type,
+                    color: amsStatus.external_spool.color,
+                    material_id: amsStatus.external_spool.material_id,
+                  })}
+                </div>
+              ) : (
+                <div className="no-filaments">No external spool loaded</div>
+              )}
+            </div>
           )}
         </div>
       ) : (

--- a/pwa/src/components/ConfigurationSummary.tsx
+++ b/pwa/src/components/ConfigurationSummary.tsx
@@ -184,7 +184,23 @@ function ConfigurationSummary({
 
   // Get AMS slot details for a mapping
   const getAMSSlotDetails = (mapping: FilamentMapping) => {
-    if (!amsStatus?.success || !amsStatus.ams_units) return null;
+    if (!amsStatus?.success) return null;
+
+    // Check if it's external spool (254 or 255)
+    if (
+      (mapping.ams_unit_id === 254 || mapping.ams_unit_id === 255) &&
+      amsStatus.external_spool?.available
+    ) {
+      return {
+        slot_id: amsStatus.external_spool.slot_id,
+        filament_type: amsStatus.external_spool.filament_type,
+        color: amsStatus.external_spool.color,
+        material_id: amsStatus.external_spool.material_id,
+      };
+    }
+
+    // Otherwise check AMS units
+    if (!amsStatus.ams_units) return null;
 
     const unit = amsStatus.ams_units.find(
       u => u.unit_id === mapping.ams_unit_id
@@ -287,8 +303,10 @@ function ConfigurationSummary({
                         {amsSlot ? (
                           <>
                             <span className="ams-slot">
-                              Unit {mapping!.ams_unit_id}, Slot{' '}
-                              {mapping!.ams_slot_id}
+                              {mapping!.ams_unit_id === 254 ||
+                              mapping!.ams_unit_id === 255
+                                ? 'External Spool'
+                                : `Unit ${mapping!.ams_unit_id}, Slot ${mapping!.ams_slot_id}`}
                             </span>
                             <span className="ams-type">
                               {amsSlot.filament_type}

--- a/pwa/src/components/FilamentMappingConfig.tsx
+++ b/pwa/src/components/FilamentMappingConfig.tsx
@@ -261,24 +261,40 @@ function FilamentMappingConfig({
   const getAvailableSlots = (): AMSSlotOption[] => {
     const slots: AMSSlotOption[] = [];
 
-    if (amsStatus?.success && amsStatus.ams_units) {
-      amsStatus.ams_units.forEach(unit => {
-        unit.filaments.forEach(filament => {
-          // Skip empty slots
-          if (filament.filament_type === 'Empty') {
-            return;
-          }
+    if (amsStatus?.success) {
+      // Add AMS slots
+      if (amsStatus.ams_units) {
+        amsStatus.ams_units.forEach(unit => {
+          unit.filaments.forEach(filament => {
+            // Skip empty slots
+            if (filament.filament_type === 'Empty') {
+              return;
+            }
 
-          slots.push({
-            unit_id: unit.unit_id,
-            slot_id: filament.slot_id,
-            filament_type: filament.filament_type,
-            color: filament.color,
-            label: `Unit ${unit.unit_id}, Slot ${filament.slot_id}: ${filament.filament_type} (${filament.color})`,
-            value: `${unit.unit_id}-${filament.slot_id}`,
+            slots.push({
+              unit_id: unit.unit_id,
+              slot_id: filament.slot_id,
+              filament_type: filament.filament_type,
+              color: filament.color,
+              label: `Unit ${unit.unit_id}, Slot ${filament.slot_id}: ${filament.filament_type} (${filament.color})`,
+              value: `${unit.unit_id}-${filament.slot_id}`,
+            });
           });
         });
-      });
+      }
+
+      // Add external spool if available
+      if (amsStatus.external_spool?.available) {
+        const extId = amsStatus.external_spool.slot_id || 254;
+        slots.push({
+          unit_id: extId,
+          slot_id: extId,
+          filament_type: amsStatus.external_spool.filament_type,
+          color: amsStatus.external_spool.color,
+          label: `External Spool: ${amsStatus.external_spool.filament_type} (${amsStatus.external_spool.color})`,
+          value: `${extId}-${extId}`,
+        });
+      }
     }
 
     return slots;
@@ -298,17 +314,51 @@ function FilamentMappingConfig({
   const handleMappingChange = (filamentIndex: number, slotValue: string) => {
     let newMappings = [...filamentMappings];
 
-    // Remove existing mapping for this filament index
-    newMappings = newMappings.filter(m => m.filament_index !== filamentIndex);
-
-    // Add new mapping if a slot is selected
     if (slotValue) {
       const [unitId, slotId] = slotValue.split('-').map(Number);
-      newMappings.push({
-        filament_index: filamentIndex,
-        ams_unit_id: unitId,
-        ams_slot_id: slotId,
-      });
+
+      // Check if external spool (unit 254 or 255) is selected
+      if (unitId === 254 || unitId === 255) {
+        // External spool selected - apply to all filaments
+        newMappings = [];
+        for (let i = 0; i < filamentRequirements.filament_count; i++) {
+          newMappings.push({
+            filament_index: i,
+            ams_unit_id: unitId,
+            ams_slot_id: slotId,
+          });
+        }
+      } else {
+        // Regular AMS slot selected
+        // First, check if we're currently using external spool for all
+        const wasUsingExternalSpool = filamentMappings.every(
+          m => m.ams_unit_id === 254 || m.ams_unit_id === 255
+        );
+
+        if (wasUsingExternalSpool) {
+          // Switching from external spool to AMS - clear all mappings first
+          newMappings = [
+            {
+              filament_index: filamentIndex,
+              ams_unit_id: unitId,
+              ams_slot_id: slotId,
+            },
+          ];
+        } else {
+          // Normal mapping update
+          newMappings = newMappings.filter(
+            m => m.filament_index !== filamentIndex
+          );
+          newMappings.push({
+            filament_index: filamentIndex,
+            ams_unit_id: unitId,
+            ams_slot_id: slotId,
+          });
+        }
+      }
+    } else {
+      // Clearing a mapping
+      newMappings = newMappings.filter(m => m.filament_index !== filamentIndex);
     }
 
     onMappingChange(newMappings);

--- a/pwa/src/components/PlateSelector.tsx
+++ b/pwa/src/components/PlateSelector.tsx
@@ -40,6 +40,45 @@ interface SliceProgress {
   };
 }
 
+// Helper function to get mapped slot from either AMS units or external spool
+function getMappedSlot(
+  mapping: FilamentMapping | undefined,
+  amsStatus: AMSStatusResponse | null
+): { filament_type: string; color: string } | null {
+  if (!mapping || !amsStatus) return null;
+
+  // Check if it's external spool (254 or 255)
+  if (
+    (mapping.ams_unit_id === 254 || mapping.ams_unit_id === 255) &&
+    amsStatus.external_spool?.available
+  ) {
+    return {
+      filament_type: amsStatus.external_spool.filament_type,
+      color: amsStatus.external_spool.color,
+    };
+  }
+
+  // Otherwise check AMS units
+  if (amsStatus.ams_units) {
+    const unit = amsStatus.ams_units.find(
+      u => u.unit_id === mapping.ams_unit_id
+    );
+    if (unit) {
+      const filament = unit.filaments.find(
+        f => f.slot_id === mapping.ams_slot_id
+      );
+      if (filament) {
+        return {
+          filament_type: filament.filament_type,
+          color: filament.color,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
 interface FilamentPillWithDropdownProps {
   index: number;
   type: string;
@@ -53,6 +92,7 @@ interface FilamentPillWithDropdownProps {
   filamentMappings?: FilamentMapping[];
   onMappingChange?: (mappings: FilamentMapping[]) => void;
   disabled?: boolean;
+  totalFilamentCount?: number;
 }
 
 // Component for interactive filament pill with dropdown
@@ -66,6 +106,7 @@ function FilamentPillWithDropdown({
   filamentMappings = [],
   onMappingChange,
   disabled = false,
+  totalFilamentCount = 4,
 }: FilamentPillWithDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -99,22 +140,53 @@ function FilamentPillWithDropdown({
   const handleMappingSelect = (unitId: number, slotId: number) => {
     if (!onMappingChange) return;
 
-    // Start with current mappings
-    const newMappings = [...filamentMappings];
+    let newMappings = [...filamentMappings];
 
-    // Remove any existing mapping for this filament index
-    const filteredMappings = newMappings.filter(
-      m => m.filament_index !== index
-    );
+    // Check if external spool (unit 254 or 255) is selected
+    if (unitId === 254 || unitId === 255) {
+      // External spool selected - apply to all filaments
+      newMappings = [];
+      for (let i = 0; i < totalFilamentCount; i++) {
+        newMappings.push({
+          filament_index: i,
+          ams_unit_id: unitId,
+          ams_slot_id: slotId,
+        });
+      }
+    } else {
+      // Regular AMS slot selected
+      // First, check if we're currently using external spool for all
+      const wasUsingExternalSpool = filamentMappings.every(
+        m => m.ams_unit_id === 254 || m.ams_unit_id === 255
+      );
 
-    // Add the new mapping
-    filteredMappings.push({
-      filament_index: index,
-      ams_unit_id: unitId,
-      ams_slot_id: slotId,
-    });
+      if (wasUsingExternalSpool) {
+        // Switching from external spool to AMS - clear all mappings first
+        newMappings = [
+          {
+            filament_index: index,
+            ams_unit_id: unitId,
+            ams_slot_id: slotId,
+          },
+        ];
+      } else {
+        // Normal mapping update
+        // Remove any existing mapping for this filament index
+        const filteredMappings = newMappings.filter(
+          m => m.filament_index !== index
+        );
 
-    onMappingChange(filteredMappings);
+        // Add the new mapping
+        filteredMappings.push({
+          filament_index: index,
+          ams_unit_id: unitId,
+          ams_slot_id: slotId,
+        });
+        newMappings = filteredMappings;
+      }
+    }
+
+    onMappingChange(newMappings);
     setIsOpen(false);
   };
 
@@ -159,7 +231,9 @@ function FilamentPillWithDropdown({
               }}
             >
               <span className="mapped-info">
-                AMS {mapping.ams_unit_id}-{mapping.ams_slot_id}
+                {mapping.ams_unit_id === 254 || mapping.ams_unit_id === 255
+                  ? 'Ext'
+                  : `AMS ${mapping.ams_unit_id}-${mapping.ams_slot_id}`}
               </span>
               <span className="mapped-type">{mappedSlot.filament_type}</span>
             </div>
@@ -225,6 +299,37 @@ function FilamentPillWithDropdown({
                   </div>
                 );
               })
+          )}
+
+          {/* Add external spool if available */}
+          {amsStatus?.external_spool?.available && (
+            <div
+              className={`dropdown-option ${
+                mapping?.ams_unit_id ===
+                (amsStatus.external_spool.slot_id || 254)
+                  ? 'selected'
+                  : ''
+              }`}
+              onClick={() => {
+                const extId = amsStatus.external_spool?.slot_id || 254;
+                handleMappingSelect(extId, extId);
+              }}
+            >
+              <div
+                className="option-color-swatch"
+                style={{ backgroundColor: amsStatus.external_spool.color }}
+              />
+              <div className="option-details">
+                <span className="option-label">External Spool</span>
+                <span className="option-type">
+                  {amsStatus.external_spool.filament_type}
+                </span>
+              </div>
+              {mapping?.ams_unit_id ===
+                (amsStatus.external_spool.slot_id || 254) && (
+                <span className="selected-indicator">✓</span>
+              )}
+            </div>
           )}
         </div>
       )}
@@ -997,16 +1102,10 @@ function PlateSelector({
                               const mapping = filamentMappings?.find(
                                 m => m.filament_index === index
                               );
-                              const mappedSlot =
-                                mapping && amsStatus?.ams_units
-                                  ? amsStatus.ams_units
-                                      .find(
-                                        u => u.unit_id === mapping.ams_unit_id
-                                      )
-                                      ?.filaments.find(
-                                        f => f.slot_id === mapping.ams_slot_id
-                                      )
-                                  : null;
+                              const mappedSlot = getMappedSlot(
+                                mapping,
+                                amsStatus
+                              );
 
                               return (
                                 <FilamentPillWithDropdown
@@ -1024,6 +1123,9 @@ function PlateSelector({
                                   filamentMappings={filamentMappings}
                                   onMappingChange={onMappingChange}
                                   disabled={disabled || !amsStatus}
+                                  totalFilamentCount={
+                                    activeFilamentRequirements.filament_count
+                                  }
                                 />
                               );
                             }
@@ -1222,14 +1324,7 @@ function PlateSelector({
                           const mapping = filamentMappings?.find(
                             m => m.filament_index === index
                           );
-                          const mappedSlot =
-                            mapping && amsStatus?.ams_units
-                              ? amsStatus.ams_units
-                                  .find(u => u.unit_id === mapping.ams_unit_id)
-                                  ?.filaments.find(
-                                    f => f.slot_id === mapping.ams_slot_id
-                                  )
-                              : null;
+                          const mappedSlot = getMappedSlot(mapping, amsStatus);
 
                           return (
                             <FilamentPillWithDropdown
@@ -1246,6 +1341,9 @@ function PlateSelector({
                               filamentMappings={filamentMappings}
                               onMappingChange={onMappingChange}
                               disabled={disabled || !amsStatus}
+                              totalFilamentCount={
+                                filamentRequirements.filament_count
+                              }
                             />
                           );
                         }

--- a/pwa/src/styles/ams-filament.css
+++ b/pwa/src/styles/ams-filament.css
@@ -10,6 +10,19 @@
   border: 1px solid var(--color-border-primary);
 }
 
+/* External Spool Section */
+.external-spool-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border-primary);
+}
+
+.external-spool-section h4 {
+  color: var(--color-primary);
+  margin: 0 0 0.75rem 0;
+  font-size: 1.1rem;
+}
+
 .status-header {
   display: flex;
   justify-content: space-between;

--- a/pwa/src/types/api.ts
+++ b/pwa/src/types/api.ts
@@ -15,10 +15,19 @@ export interface AMSUnit {
   filaments: AMSFilament[];
 }
 
+export interface ExternalSpool {
+  slot_id: number;
+  filament_type: string;
+  color: string;
+  material_id?: string;
+  available: boolean;
+}
+
 export interface AMSStatusResponse {
   success: boolean;
   message: string;
   ams_units?: AMSUnit[];
+  external_spool?: ExternalSpool;
   error_details?: string;
 }
 
@@ -28,6 +37,7 @@ export interface PrinterStatusResponse {
   printer_model?: string;
   printer_name?: string;
   ams_units?: AMSUnit[];
+  external_spool?: ExternalSpool;
   error_details?: string;
 }
 
@@ -199,6 +209,7 @@ export interface FilamentMatchResult {
   ams_slot_id: number;
   match_quality: string; // "perfect", "type_only", "fallback", "none"
   confidence: number;
+  is_external_spool?: boolean;
 }
 
 export interface FilamentMatchResponse {


### PR DESCRIPTION
## Summary
This PR fixes the external spool functionality to make it visible and selectable in both the status and configuration tabs, addressing issue #190.

## Changes
- **Backend Updates:**
  - Fixed MQTT data parsing to check for `vt_tray` at the correct location for X1C printers
  - Added support for both external spool IDs (254 and 255) to handle different printer models
  - Updated availability detection to check for `filament_type` existence instead of `state` field
  - Always include external spool in API responses (not just when available)

- **Frontend Updates:**
  - Added external spool to the filament mapping dropdown menu
  - Display "Ext" abbreviation when external spool is selected (space-efficient)
  - Hide slot numbers for external spool in status display
  - Updated configuration summary to show "External Spool" instead of unit/slot numbers

## Testing
- ✅ All backend tests pass (434 passed, 26 skipped)
- ✅ All frontend tests pass (186 passed)
- ✅ Code formatted and linted
- ✅ Tested with real X1C printer data showing TPU in external spool

## Screenshots
The external spool now appears in:
1. Status tab - shows the external spool with loaded filament
2. Configuration dropdown - allows selection for filament mapping
3. Selected state shows "Ext" for space efficiency

Fixes #190

🤖 Generated with [Claude Code](https://claude.ai/code)